### PR TITLE
fix_check_timestamps

### DIFF
--- a/ioos_qartod/qc_tests/auxillary_checks.py
+++ b/ioos_qartod/qc_tests/auxillary_checks.py
@@ -13,7 +13,8 @@ def check_timestamps(times, max_time_interval=None):
     # check if there are differences between sorted and unsorted, and then
     # see if if there are any duplicate times.  Then check that none of the
     # diffs exceeds the sorted time
-    if not np.array_equal(time_diff, sort_diff) or np.any(sort_diff == 0):
+    zero = np.array(0, dtype=time_diff.dtype)
+    if not np.array_equal(time_diff, sort_diff) or np.any(sort_diff == zero):
         return False
     elif (max_time_interval is not None and
           np.any(sort_diff > max_time_interval)):


### PR DESCRIPTION
`Timedelta` and `int` comparison fail in `numpy >= 1.10.0`.  This fix is OK for all both numpy 19 and 110.