### PR TITLE
Faster Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,21 @@
 language: python
-python:
-  - "2.7"
-install:
-  - pip install -r requirements.txt
-script: nosetests -w test
+
+sudo: false
+
+env:
+    - CONDA="python=2.7"
+    - CONDA="python=3.4"
+    - CONDA="python=3.5"
+
+before_install:
+    - wget http://bit.ly/miniconda -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - conda update --yes --all
+    - conda config --add channels ioos --force
+    - travis_retry conda create --yes -n TEST $CONDA --file requirements.txt
+    - source activate TEST
+    - travis_retry conda install --yes nose
+
+script:
+    - nosetests -w test


### PR DESCRIPTION
Tests for python `2.7`, `3.4`, and `3.5` run in 2 min 3 sec in this setup.  The original setup takes  >5 min just for python `2.7`.